### PR TITLE
chore: migrate from odpf to goto

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,6 @@ jobs:
       - name: Get release tag
         id: get_version
         uses: battila7/get-version-action@v2
-      - name: Login to GitHub Packages Docker Registry
-        uses: docker/login-action@v1
-        with:
-          registry: docker.pkg.github.com
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
@@ -31,17 +25,13 @@ jobs:
           context: .
           push: true
           tags: |
-            docker.pkg.github.com/${{ github.repository }}/cosmos:latest
-            docker.pkg.github.com/${{ github.repository }}/cosmos:${{ steps.get_version.outputs.version-without-v }}
-            odpf/cosmos:latest
-            odpf/cosmos:${{ steps.get_version.outputs.version-without-v }}
+            gotocompany/cosmos:latest
+            gotocompany/cosmos:${{ steps.get_version.outputs.version-without-v }}
       - name: Build and Push Cube
         uses: docker/build-push-action@v2
         with:
           context: ./cube-server
           push: true
           tags: |
-            docker.pkg.github.com/${{ github.repository }}/cosmos-cube:latest
-            docker.pkg.github.com/${{ github.repository }}/cosmos-cube:${{ steps.get_version.outputs.version-without-v }}
-            odpf/cosmos-cube:latest
-            odpf/cosmos-cube:${{ steps.get_version.outputs.version-without-v }}
+            gotocompany/cosmos-cube:latest
+            gotocompany/cosmos-cube:${{ steps.get_version.outputs.version-without-v }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
-        run: npm ci
+        run: yarn install --frozen-lockfile
       - name: Check Lint
         run: npm run lint
       - name: Run Tests

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Cosmos
 
-[![node-ci](https://github.com/odpf/cosmos/actions/workflows/test.yml/badge.svg)](https://github.com/odpf/cosmos/actions/workflows/test.yml)
-[![codecov](https://codecov.io/gh/odpf/cosmos/branch/main/graph/badge.svg?token=2CkqMa9YmH)](https://codecov.io/gh/odpf/cosmos)
+[![node-ci](https://github.com/goto/cosmos/actions/workflows/test.yml/badge.svg)](https://github.com/goto/cosmos/actions/workflows/test.yml)
+[![codecov](https://codecov.io/gh/goto/cosmos/branch/main/graph/badge.svg?token=2CkqMa9YmH)](https://codecov.io/gh/goto/cosmos)
 
 ## Getting Started
 
-Cosmos Docker image can be found [here](https://github.com/orgs/odpf/packages?repo_name=cosmos)
+Cosmos Docker image can be found [here](https://github.com/orgs/goto/packages?repo_name=cosmos)
 
 ```sh
-docker run -e MONGODB_HOST=mongodb://127.0.0.1:27017/cosmos -p 8000:8000 docker.pkg.github.com/odpf/cosmos/cosmos
+docker run -e MONGODB_HOST=mongodb://127.0.0.1:27017/cosmos -p 8000:8000 docker.pkg.github.com/goto/cosmos/cosmos
 ```
 
 Visit [http://localhost:8000/documentation](http://localhost:8000/documentation) to view API documentation.
@@ -33,7 +33,7 @@ CUBE_URL (default: "http://localhost:4000" )
 1. Clone the repo
 
    ```sh
-   $ git clone https://github.com/odpf/cosmos
+   $ git clone https://github.com/goto/cosmos
    $ cd cosmos
    ```
 
@@ -71,7 +71,7 @@ $ npm test
 
 ## Versioning
 
-We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags](https://github.com/odpf/cosmos/tags).
+We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags](https://github.com/goto/cosmos/tags).
 
 ## License
 

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -16,7 +16,7 @@ Cosmos is developed with
 In order to install this project locally, you can follow the instructions below:
 
 ```text
-$ git clone git@github.com:odpf/cosmos.git
+$ git clone git@github.com:goto/cosmos.git
 $ cd cosmos
 $ docker-compose up
 ```

--- a/docs/contribute/contribution.md
+++ b/docs/contribute/contribution.md
@@ -3,7 +3,7 @@
 The following is a set of guidelines for contributing to Cosmos. These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request. Here are some important resources:
 
 - [Concepts]() section will explain you about Cosmos codebase,
-- Github [issues](https://github.com/odpf/cosmos/issues) track the ongoing and reported issues.
+- Github [issues](https://github.com/goto/cosmos/issues) track the ongoing and reported issues.
 
 ## How can I contribute?
 
@@ -34,4 +34,4 @@ Please follow these practices for you change to get merged fast and smoothly:
 - If you are introducing a completely new feature or making any major changes in an existing one, we recommend to start with an RFC and get consensus on the basic design first.
 - Make sure your local build is running with all the tests and is passing style checks.
 - If your change is related to user-facing protocols/configurations, you need to make the corresponding change in the documentation as well.
-- Docs live in the code repo under [`docs`](https://github.com/odpf/cosmos/blob/main/docs/README.md) so that changes to it can be done in the same PR as changes to the code.
+- Docs live in the code repo under [`docs`](https://github.com/goto/cosmos/blob/main/docs/README.md) so that changes to it can be done in the same PR as changes to the code.

--- a/docs/contribute/release_process.md
+++ b/docs/contribute/release_process.md
@@ -20,4 +20,4 @@ gh release create <tag-version> -F CHANGELOG.md
 
 - For new major or minor release, create and check out the release branch for the new stream, e.g. `v0.6-branch`. For a patch version, check out the stream's release branch.
 - We use an [open source change log generator](https://github.com/conventional-changelog/standard-version) to generate changelogs.
-- Update the [CHANGELOG.md](https://github.com/odpf/cosmos/blob/master/CHANGELOG.md). See the [Creating a change log](release_process.md#creating-a-change-log) guide and commit
+- Update the [CHANGELOG.md](https://github.com/goto/cosmos/blob/master/CHANGELOG.md). See the [Creating a change log](release_process.md#creating-a-change-log) guide and commit

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -1,14 +1,14 @@
 # Deployment
 
-Deploying Cosmos is very simple with the docker image. You can find the cosmos docker image on [dockerhub](https://hub.docker.com/r/odpf/cosmos).
+Deploying Cosmos is very simple with the docker image. You can find the cosmos docker image on [dockerhub](https://hub.docker.com/r/gotocompany/cosmos).
 
 ## Pre-requisites
 
 1. Cosmos needs a MongoDB connection.
-2. [Cube.js](https://hub.docker.com/r/odpf/cosmos-cube) instance running.
+2. [Cube.js](https://hub.docker.com/r/gotocompany/cosmos-cube) instance running.
 
 ```
-docker run -e MONGODB_HOST=mongodb://127.0.0.1:27017/cosmos -p 8000:8000 odpf/cosmos
+docker run -e MONGODB_HOST=mongodb://127.0.0.1:27017/cosmos -p 8000:8000 gotocompany/cosmos
 ```
 
 ## Environment Variables

--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/odpf/cosmos.git"
+    "url": "git+https://github.com/goto/cosmos.git"
   },
   "author": "",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/odpf/cosmos/issues"
+    "url": "https://github.com/goto/cosmos/issues"
   },
-  "homepage": "https://github.com/odpf/cosmos#readme",
+  "homepage": "https://github.com/goto/cosmos#readme",
   "devDependencies": {
     "@types/confidence": "^1.4.30",
     "@types/faker": "^5.5.6",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prebuild": "npm run clean",
     "build": "ttsc -p tsconfig.build.json",
     "dev": "nodemon",
-    "test": "jest"
+    "test": "jest --silent"
   },
   "repository": {
     "type": "git",

--- a/tests/app/metric/meta/resource.ts
+++ b/tests/app/metric/meta/resource.ts
@@ -11,7 +11,7 @@ describe('Metric/Meta::Resource', () => {
       const spy = jest.spyOn(Metric, 'findByUrn').mockResolvedValueOnce(null);
       try {
         await Resource.list('metricUrn');
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).toEqual('Metric not found for urn: metricUrn');
       }
       expect(spy).toHaveBeenCalledWith('metricUrn');
@@ -33,7 +33,7 @@ describe('Metric/Meta::Resource', () => {
       const spy = jest.spyOn(Metric, 'findByUrn').mockResolvedValueOnce(null);
       try {
         await Resource.get('metricUrn', 'meta1');
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).toEqual('Metric not found for urn: metricUrn');
       }
       expect(spy).toHaveBeenCalledWith('metricUrn');
@@ -49,7 +49,7 @@ describe('Metric/Meta::Resource', () => {
       const spy = jest.spyOn(Metric, 'findByUrn').mockResolvedValueOnce(metric);
       try {
         await Resource.get('metricUrn', 'meta1');
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).toEqual('Meta meta1 not found for Metric: metricUrn');
       }
       expect(spy).toHaveBeenCalledWith('metricUrn');
@@ -103,7 +103,7 @@ describe('Metric/Meta::Resource', () => {
       const spy = jest.spyOn(Metric, 'findByUrn').mockResolvedValueOnce(null);
       try {
         await Resource.update(urn, metaName, updatePayload);
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).toEqual('Metric not found for urn: test-urn');
       }
       expect(spy).toHaveBeenCalledWith('test-urn');
@@ -122,7 +122,7 @@ describe('Metric/Meta::Resource', () => {
       const spy = jest.spyOn(Metric, 'findByUrn').mockResolvedValueOnce(metric);
       try {
         await Resource.update(urn, metaName, updatePayload);
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).toEqual('Meta meta1 not found for Metric: test-urn');
       }
       expect(spy).toHaveBeenCalledWith('test-urn');
@@ -169,7 +169,7 @@ describe('Metric/Meta::Resource', () => {
       const spy = jest.spyOn(Metric, 'findByUrn').mockResolvedValueOnce(null);
       try {
         await Resource.deleteMeta(urn, metaName);
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).toEqual('Metric not found for urn: test-urn');
       }
       expect(spy).toHaveBeenCalledWith('test-urn');
@@ -187,7 +187,7 @@ describe('Metric/Meta::Resource', () => {
       const spy = jest.spyOn(Metric, 'findByUrn').mockResolvedValueOnce(metric);
       try {
         await Resource.deleteMeta(urn, metaName);
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).toEqual('Meta meta1 not found for Metric: test-urn');
       }
       expect(spy).toHaveBeenCalledWith('test-urn');

--- a/tests/app/metric/resource.ts
+++ b/tests/app/metric/resource.ts
@@ -31,12 +31,11 @@ describe('Metric::Resource', () => {
           urn
         });
       const connectionSpy = jest.spyOn(Metric, 'create').mockResolvedValue({
-        // @ts-ignore
         toJSON: () => ({
           ...metric,
           urn
         })
-      });
+      } as never);
       const result = await Resource.create(data);
       expect(result.urn).toBe(urn);
 


### PR DESCRIPTION
## Changes

1. migrate https://hub.docker.com/u/odpf to https://hub.docker.com/u/gotocompany
2. migrate reference from https://github.com/odpf/cosmos to https://github.com/goto/cosmos

Notes:
1. This repo is still using npm package `@odpf/apsara: ^0.5.6` because `@goto-company/apsara` only has newest version with latest changes. Migrating to `@goto-company/apsara` will break `cosmos/cube-server` due to outdated component used by cosmos.